### PR TITLE
post gen hooks - add aws profiles and skip s3 sync when no s3_bucket

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,13 +1,14 @@
 #! /bin/bash
+set -e
 
 # Initial sync of data folder to project specific prefix under the manifold-projects bucket
 echo "Creating shared data folders at s3://manifold-projects/{{ cookiecutter.repo_name }}..."
-aws s3 sync data s3://manifold-projects/{{ cookiecutter.repo_name }} 
+aws s3 sync data s3://manifold-projects/{{ cookiecutter.repo_name }} --profile {{ cookiecutter.aws_profile }}
 echo "Done."
 
-# Log in to ECR 
+# Log in to ECR
 echo "Performing docker login to AWS container registry..."
-aws ecr get-login --no-include-email | sh
+aws ecr get-login --no-include-email --profile {{ cookiecutter.aws_profile }}| sh
 echo "Done."
 
 echo "All set! Run the start.sh script and open Kitematic from the Docker minibar menu to make sure your container is running the Jupyter service."

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,10 +1,18 @@
 #! /bin/bash
 set -e
 
+lc(){
+    echo "$1" |tr '[:upper:]' '[:lower:]'
+}
+
 # Initial sync of data folder to project specific prefix under the manifold-projects bucket
-echo "Creating shared data folders at s3://manifold-projects/{{ cookiecutter.repo_name }}..."
-aws s3 sync data s3://manifold-projects/{{ cookiecutter.repo_name }} --profile {{ cookiecutter.aws_profile }}
-echo "Done."
+if [[ $(lc "{{ cookiecutter.s3_bucket }}") != "[optional]"* ]] ;
+then
+    S3_PATH="s3://{{ cookiecutter.s3_bucket }}/{{ cookiecutter.repo_name }}"
+    echo "Creating shared data folders at $S3_PATH..."
+    aws s3 sync data "$S3_PATH" --profile {{ cookiecutter.aws_profile }}
+    echo "Done."
+fi
 
 # Log in to ECR
 echo "Performing docker login to AWS container registry..."


### PR DESCRIPTION
- add aws profiles to commands
- set -e in post_gen script (stop the script if any command fails)
- skip s3 sync when no s3_bucket is specified; this is a bit of a hack since we use the default value as a prompt description

todos:
- handle s3 bucket encryption